### PR TITLE
docs(stremio): Move stremio gdrive into http addons

### DIFF
--- a/docs/stremio/extras/stremio-gdrive.mdx
+++ b/docs/stremio/extras/stremio-gdrive.mdx
@@ -1,9 +1,0 @@
----
-title: Stremio-gdrive
-sidebar_label: Stremio-gdrive
-description: View files from Team Drives within Stremio
----
-
-Stremio-gdrive is a Stremio addon that allows you to view files from Google Drive. 
-
-You can use [this GitHub repository](https://github.com/ShuvamJaswal/Gdrive-Stremio-Update) to set this up. 

--- a/docs/stremio/guide.mdx
+++ b/docs/stremio/guide.mdx
@@ -902,6 +902,18 @@ Here is a list of some HTTP addons:
 </div>
 </details>
 
+<details>
+<summary>stremio-gdrive</summary>
+<div>
+
+    Stremio-gdrive is a Stremio addon that allows you to view files from Google Drive. 
+
+    For it to work, you will need to join some team drives. You can find some [here](https://t.me/s/teamdrives).
+
+    You can use [this GitHub repository](https://github.com/ShuvamJaswal/Gdrive-Stremio-Update) to set this up. 
+
+</div>
+</details>
 
 The basic setup for Stremio has now been completed. You can now search for a movie and you will be provided with high quality links to stream from.
 

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -73,7 +73,6 @@ const sidebars: SidebarsConfig = {
 								"stremio/extras/debrid-media-manager", 
 								"stremio/extras/stremio-server",
 								"stremio/extras/discord-integration",
-								"stremio/extras/stremio-gdrive",
 								"stremio/extras/pimp-my-stremio",
 								"stremio/extras/stremio-downloader"
 							]


### PR DESCRIPTION
Add steps for stremio-gdrive under HTTP addons rather than a separate page under Extras. 

stremio-gdrive is an addon that uses HTTP streams so it doesn't make sense for it to be under Extras. 