### PR TITLE
add vision pro to web tab and other improvements

### DIFF
--- a/docs/stremio/intro.mdx
+++ b/docs/stremio/intro.mdx
@@ -43,7 +43,7 @@ It is not, however, required.
 Stremio can be used on many devices, including but not limited to:
 
 - Android
-- iOS, iPadOS
+- iPhone and iPad
 - Windows, macOS, Linux
 - Fire TV
 - Android TV
@@ -51,6 +51,7 @@ Stremio can be used on many devices, including but not limited to:
 - LG TV (2020+ Models)
 - Rasberry Pi 
 - Meta Quest
+- Apple Vision Pro
 
 You can also use Stremio without installing any application from your browser at [Stremio Web](https://web.stremio.com/).
 This may not work on some devices.

--- a/docs/stremio/platform/_ios.mdx
+++ b/docs/stremio/platform/_ios.mdx
@@ -1,4 +1,0 @@
-The app available in the App store is limited and will not let you watch content.
-
-To use Stremio on your iPhone or iPad, follow the steps in the iOS tab under the [Web tab](setup?platform=web#downloading-stremio) to set up Stremio Web on your device. 
-

--- a/docs/stremio/platform/_web.mdx
+++ b/docs/stremio/platform/_web.mdx
@@ -4,18 +4,18 @@ import Admonition from "@theme/Admonition";
 
 [Stremio Web](https://web.stremio.com) is a web version of Stremio doesn't require any signup or installation.
 
-<Tabs className="custom-tabs" queryString="platform">
+**The following steps are for using Stremio Web only**. 
+It is recommended that you use dedicated apps, if available, for the best experience.
+Please check the other tabs for information on setting up dedicated apps.
 
-    <TabItem label="PC" value="web-pc" default>
+:::info
+There is no dedicated app for Stremio for the Apple ecosystem. 
+You may still use Stremio Web on most Apple devices, which will require a bit more work to set up, but it's a straightforward process that has clear instructions below.
+:::
 
-
-        On PC, playback in the browser will work most of the time. However, you may encounter audio issues and you won't be able to stream torrents without a streaming server.
-
-        Therefore, you will need to follow the steps below to [setup a streaming server on your android phone or desktop.](#stremio-server)
-
-    </TabItem>
-
-        <TabItem value="web-ios" label="iOS">
+<Tabs className="custom-tabs" queryString="web-platform">
+        
+    <TabItem value="ios" label="iOS">
 
         The app available in the App Store is very limited and is pretty useless.
 
@@ -51,7 +51,33 @@ import Admonition from "@theme/Admonition";
         You can now open a link and it should open in the external player you selected.
     </TabItem>
 
-    <TabItem label="Android" value="web-android">
+    <TabItem label="Vision Pro" value="vision-pro">
+    
+        To get the best experience on Apple Vision Pro, you should use the Moon VR Player on Stremio Web. 
+
+        Follow [this blog post](https://blog.stremio.com/how-to-use-stremio-web-on-vision-pro/) to set up Stremio Web on your Apple Vision Pro.
+        Ensure that you select the Moon VR Player as the external player when setting up Stremio Web.
+
+        After setting up Stremio Web, you should ensure that Moon VR Player is installed on your Apple Vision Pro.
+
+        Limitations:
+            - Torrent streaming is not possible. This means **a debrid service is required** to stream torrents.
+            - No episode progress tracking.
+            - Addon-provided subtitles cannot be used (you can still use the embedded subtitles provided by the video file).
+
+        To resolve these limitations, you can [setup a streaming server on your android phone or desktop.](#stremio-server)
+    </TabItem>
+
+    <TabItem label="PC" value="pc" default>
+
+
+        On PC, playback in the browser will work most of the time. However, you may encounter audio issues and you won't be able to stream torrents without a streaming server.
+
+        Therefore, you will need to follow the steps below to [setup a streaming server on your android phone or desktop.](#stremio-server)
+
+    </TabItem>
+
+    <TabItem label="Android" value="android">
 
         If you are using Stremio Web on your android phone, then you can add it to your home screen for easy access. Here are the steps to do this:
 

--- a/docs/stremio/platform/_web.mdx
+++ b/docs/stremio/platform/_web.mdx
@@ -15,7 +15,7 @@ You may still use Stremio Web on most Apple devices, which will require a bit mo
 
 <Tabs className="custom-tabs" queryString="web-platform">
         
-    <TabItem value="ios" label="iOS">
+    <TabItem value="ios" label="iPhone & iPad">
 
         The app available in the App Store is very limited and is pretty useless.
 

--- a/docs/stremio/setup.mdx
+++ b/docs/stremio/setup.mdx
@@ -87,8 +87,8 @@ Head over to [Stremio](https://stremio.com/) and either [sign up for an account]
 ## Downloading Stremio
 
 Head to the [downloads page](https://stremio.com/downloads) and download the required package.
-:::warning
-If you want to use Stremio on your iPhone or iPad, click the `Web` tab and then the `iOS` tab.
+:::tip
+Want to use Stremio on your Apple device? Check the [Web](?platform=web#downloading-stremio) section below for more information.
 :::
 
 Here are the instructions for each platform, if you are viewing on a mobile phone, you will need to scroll horizontally to see all the different platform instructions. 

--- a/docs/stremio/setup.mdx
+++ b/docs/stremio/setup.mdx
@@ -35,7 +35,6 @@ import Admonition from "@theme/Admonition";
 import Web from "./platform/_web.mdx";
 import Pc from "./platform/_pc.mdx";
 import Android from "./platform/_android.mdx";
-import Ios from "./platform/_ios.mdx"
 import AndroidTv from "./platform/_android-tv.mdx";
 import FireTv from "./platform/_fire-tv.mdx";
 import SamsungTv from "./platform/_samsung-tv.mdx";
@@ -113,12 +112,6 @@ Here are the instructions for each platform, if you are viewing on a mobile phon
         <Android/>
 
 	</TabItem>
-
-    <TabItem value="ios" label="iOS">
-
-        <Ios/>
-    
-    </TabItem>
 
 	<TabItem value="fire-tv" label="Fire TV">
 


### PR DESCRIPTION
- Adds a Vision Pro tab to the web category
- Removes the iOS main tab. 
- add more tips/notes for apple users to look at the web category
