### PR TITLE
Changed URL of MCenters download

### DIFF
--- a/docs/minecraft/bedrock/windows.mdx
+++ b/docs/minecraft/bedrock/windows.mdx
@@ -30,7 +30,7 @@ I do not own or have any affiliation with M Centers. I am simply providing a lin
 
 ## Using M Centers
 
-4. Download [M Centers 8.0](https://mcenters.net/Downloads/M-Centers-8th-Edition/).
+4. Download [M Centers 8.0](https://github.com/OpenM-Project/m-centers-archive/releases/latest).
 
 5. Extract the zip file and double click the EXE file: 
     ![m_centers_folder](/img/minecraft/m_centers_folder.png)


### PR DESCRIPTION
MCenters have (again) discontinued, so we have archived the latest download of MCenters 8.0. 

I have updated the URL to the archive so that now everyone can get the download again.
( We also have complete rights from MCenters to archive this )