### PR TITLE
Replace broken Kohi Den links

### DIFF
--- a/docs/aniyomi/setup.mdx
+++ b/docs/aniyomi/setup.mdx
@@ -116,11 +116,11 @@ For example, if you had a specific anime site, you could create an extension for
 
 We can make use of third-party extension repositories that contain community maintained extensions. These repositories contain extensions for a variety of different sites.
 
-We will be making use of the [Kohi Den](https://github.com/Kohi-den/extensions) repository for anime and the [Keiyoushi](https://github.com/keiyoushi/extensions) repository for manga.
+We will be making use of the [Kohi Den](https://github.com/Kohi-den/extensions-source) repository for anime and the [Keiyoushi](https://github.com/keiyoushi/extensions) repository for manga.
 
 To add the repositories, simply click the links below:
 
-- [Kohi Den](aniyomi://add-repo?url=https%3A%2F%2Fraw.githubusercontent.com%2Fkohi-den%2Fextensions%2Fmain%2Findex.min.json)
+- [Kohi Den](aniyomi://add-repo?url=https%3A%2F%2Fkohiden.xyz%2FKohi-den%2Fextensions%2Fraw%2Fbranch%2Fmain%2Findex.min.json)
 - [Keiyoushi](aniyomi://add-repo?url=https%3A%2F%2Fraw.githubusercontent.com%2Fkeiyoushi%2Fextensions%2Frepo%2Findex.min.json)
 
 If the links don't work, you can add the repositories manually by following the steps below:
@@ -143,7 +143,7 @@ If the links don't work, you can add the repositories manually by following the 
    **Kohi Den (Anime):**
 
    ```
-   https://raw.githubusercontent.com/kohi-den/extensions/main/index.min.json
+   https://kohiden.xyz/Kohi-den/extensions/raw/branch/main/index.min.json
    ```
 
    **Keiyoushi (Manga):**


### PR DESCRIPTION
The links pointing to the Kohi Den repository no longer work, and they are have now changed to point towards the domain kohiden.xyz.