### PR TITLE
Fix broken xtremio link: addon rebranded to YourIPTV

### DIFF
--- a/docs/stremio/faq.mdx
+++ b/docs/stremio/faq.mdx
@@ -479,7 +479,7 @@ Stremio does support live streams. However, its its interface is not designed fo
 
 - The [USA TV Addon](https://848b3516657c-usatv.baby-beamup.club/) can be used to watch live TV for channels in the USA.
 - [MediaFusion](https://mediafusion.elfhosted.com/configure) does provide live streams and replays for sports.
-- The [xtremio addon](https://xtremio.elfhosted.com/configure) can be used to stream content from your paid IPTV subscription.
+- The [YourIPTV addon](https://youriptv.hayd.uk/configure) can be used to stream content from your paid IPTV subscription.
 
 Please see the [Live TV section](setup#live-tv--sports) for more information.
 

--- a/docs/stremio/setup.mdx
+++ b/docs/stremio/setup.mdx
@@ -761,7 +761,7 @@ import ArgentinaTv from "./addons/argentina-tv.mdx";
 - [Mediafusion](/stremio/addons/mediafusion) provides streams for live sports and replays. It also has a few live TV channels.
   The live streams are direct streams but the replays are torrents. You can find more information above, where I covered it previously.
 - The [MammaMia](/stremio/addons/mammamia) addon also provides live TV channels.
-- If you have an IPTV provider, you can use the [xtremio](https://xtremio.elfhosted.com/configure) addon to watch content from your IPTV provider.
+- If you have an IPTV provider, you can use the [YourIPTV](https://youriptv.hayd.uk/configure) addon to watch content from your IPTV provider.
 
 ---
 


### PR DESCRIPTION
The `xtremio.elfhosted.com` link in the Live TV & Sports section of the Stremio setup guide currently returns a 404. The addon was rebranded and now lives at [youriptv.hayd.uk](https://youriptv.hayd.uk/configure).

Same addon, new home; just updating the link and display name.

```
- If you have an IPTV provider, you can use the [xtremio](https://xtremio.elfhosted.com/configure) addon to watch content from your IPTV provider.
+ If you have an IPTV provider, you can use the [YourIPTV](https://youriptv.hayd.uk/configure) addon to watch content from your IPTV provider.
```